### PR TITLE
Add -s, --single-line option for single line output

### DIFF
--- a/changelog/__init__.py
+++ b/changelog/__init__.py
@@ -171,15 +171,21 @@ def main():
                         help='current release tag (defaults to HEAD)')
     parser.add_argument('-m', '--markdown', action='store_true',
                         help='output in markdown')
+    parser.add_argument('-s', '--single-line', action='store_true',
+                        help='output as single line joined by \\n characters')
 
     args = parser.parse_args()
 
     prs = fetch_changes(args.owner, args.repo, args.previous_tag,
                         current_tag=args.current_tag)
 
-    for line in format_changes(args.owner, args.repo, prs,
-                               markdown=args.markdown):
-        print(line)
+    lines = format_changes(args.owner, args.repo, prs, markdown=args.markdown)
+
+    if not args.single_line:
+        for line in lines:
+            print(line)
+    else:
+        print('\\n'.join(lines))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
To use this output with the GitHub API to create a new release, the commit message needs to include literal `\n` characters, e.g.`"-change 1\n- change 2\n- change 3"` instead of passing the actual
newline characters themselves.

This change allows for generation of a single line of output instead of the default multi-line output.

## Additions

- Adds `-s, --single-line` command-line option to generate single line.

## Review

- @willbarton 

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
