### PR TITLE
Update docs and support programmatic invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,18 @@ pip install git+https://github.com/cfpb/github-changelog
 ## Using
 
 ```
-changelog [-h] [-m] OWNER REPO PREVIOUS [CURRENT]
+changelog [-h] [-m] OWNER REPO [PREVIOUS] [CURRENT]
 ```
 
-The `changelog` command that takes a GitHub repository owner (user or organization), repository name, and at least one tag as arguments. With those arguments it will list all GitHub pull requests that have been merged between the given tags or between the tag and `HEAD` if only one tag is given. If `-m` is specified the output will be formatted in markdown and include links to the pull requests.
+The `changelog` command takes a GitHub repository owner (user or organization), repository name and zero, one, or two tags to limit the set of changes to consider. If no tags are provided, the changelog will be computed between the latest tag and `HEAD`. One tag may be provided to set the base tag to compare against `HEAD`. Two tags may be provided to specify both base tag and ending tag. The generated changelog will list all GitHub pull requests that have been merged between the specified or inferred tags. If `-m` is specified the output will be formatted in markdown and include links to the pull requests.
 
 ### Examples
+
+```
+changelog cfpb github-changelog
+```
+
+Will generate a text changelog between the latest tag and `HEAD`.
 
 ```
 changelog cfpb github-changelog 1.0.0

--- a/changelog/__init__.py
+++ b/changelog/__init__.py
@@ -168,6 +168,16 @@ def format_changes(owner, repo, prs, markdown=False):
     return lines
 
 
+def generate_changelog(owner, repo, previous_tag=None, current_tag=None,
+                       markdown=False, single_line=False):
+
+    prs = fetch_changes(owner, repo, previous_tag, current_tag)
+    lines = format_changes(owner, repo, prs, markdown=markdown)
+
+    separator = '\\n' if single_line else '\n'
+    return separator.join(lines)
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Generate a CHANGELOG between two git tags based on GitHub"
@@ -187,16 +197,8 @@ def main():
 
     args = parser.parse_args()
 
-    prs = fetch_changes(args.owner, args.repo, previous_tag=args.previous_tag,
-                        current_tag=args.current_tag)
-
-    lines = format_changes(args.owner, args.repo, prs, markdown=args.markdown)
-
-    if not args.single_line:
-        for line in lines:
-            print(line)
-    else:
-        print('\\n'.join(lines))
+    changelog = generate_changelog(**vars(args))
+    print(changelog)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR refactors the main `changelog.py` script to expose a `generate_changelog` method that may be used to generate a changelog programmatically:

```py
def generate_changelog(owner, repo, previous_tag=None, current_tag=None,
                       markdown=False, single_line=False):
```

This PR also adds some documentation updates missed in #2.

## Changes

- `README` updates.
- Refactor of `changelog.py` to expose functionality programmatically.

## Review

- @willbarton 

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
