### PR TITLE
Add a Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.5-alpine
+
+COPY ["changelog", "/app/src/changelog/"]
+COPY ["setup.py", "/app/src/"]
+RUN cd /app/src \
+    && pip install . \
+    && mkdir /app/workdir
+
+WORKDIR /app/workdir
+ENV PYTHONUNBUFFERED="1"
+
+ENTRYPOINT ["changelog"]


### PR DESCRIPTION
This app works really well within a container; its Python and `requests`
dependencies can be wrapped up and carried around without much setup. This
Dockerfile describes what needs to be included.

It can be used like so (I added the image to my DockerHub):

```sh
docker run --rm cmc333333/github-changelog eregs regulations-parser 4.2.0
```
