### PR TITLE
Support squash-and-merge commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ changelog [-h] [-m] OWNER REPO [PREVIOUS] [CURRENT]
 
 The `changelog` command takes a GitHub repository owner (user or organization), repository name and zero, one, or two tags to limit the set of changes to consider. If no tags are provided, the changelog will be computed between the latest tag and `HEAD`. One tag may be provided to set the base tag to compare against `HEAD`. Two tags may be provided to specify both base tag and ending tag. The generated changelog will list all GitHub pull requests that have been merged between the specified or inferred tags. If `-m` is specified the output will be formatted in markdown and include links to the pull requests.
 
-Pull request merges are identified by their commit message, usually taking the form of `Merge pull request #123…`. Pull requests merged with "Squash and merge" are not currently supported.
+Pull request merges are identified by their commit message, usually taking the form of `Merge pull request #123…`. Squash-and-merged pull requests are identified by having the PR number in parentheses at the end of first line of the commit message.
 
 ### Examples
 

--- a/changelog/__init__.py
+++ b/changelog/__init__.py
@@ -21,6 +21,10 @@ if GITHUB_API_TOKEN is not None:
 Commit = namedtuple('Commit', ['sha', 'message'])
 PullRequest = namedtuple('PullRequest', ['number', 'title'])
 
+# Merge commits use a double linebreak between the branch name and the title
+MERGE_PR_RE = re.compile(r'^Merge pull request #([0-9]+) from .*\n\n(.*)')
+SQUASH_PR_RE = re.compile(r'^(.*) \(#([0-9]+)\)\n\n.*')
+
 
 class GitHubError(Exception):
     pass
@@ -103,23 +107,24 @@ def get_commits_between(owner, repo, first_commit, last_commit):
     return commits
 
 
+def is_pr(message):
+    """ Determine whether or not a commit message is a PR merge """
+    return MERGE_PR_RE.search(message) or SQUASH_PR_RE.search(message)
+
+
 def extract_pr(message):
     """ Given a PR merge commit message, extract the PR number and title """
-    if 'Merge pull request' not in message:
-        raise Exception("Commit isn't a PR merge, {}".format(message))
+    merge_match = MERGE_PR_RE.match(message)
+    squash_match = SQUASH_PR_RE.match(message)
 
-    # PR merge commits use a double line-break between the branch name
-    # and the PR title
-    merge, title = message.split('\n\n')
+    if merge_match is not None:
+        number, title = merge_match.groups()
+        return PullRequest(number=number, title=title)
+    elif squash_match is not None:
+        title, number = squash_match.groups()
+        return PullRequest(number=number, title=title)
 
-    # Find the PR number
-    number_match = re.search(r'#([0-9]+)', merge)
-    if number_match is None or len(number_match.groups()) == 0:
-        raise Exception("Unable to find PR number in {}".format(merge))
-    pr_number = number_match.groups()[0]
-
-    # Output the PR number and title
-    return PullRequest(pr_number, title)
+    raise Exception("Commit isn't a PR merge, {}".format(message))
 
 
 def fetch_changes(owner, repo, previous_tag=None, current_tag=None,
@@ -138,11 +143,7 @@ def fetch_changes(owner, repo, previous_tag=None, current_tag=None,
                                           previous_commit, current_commit)
 
     # Process the commit list looking for PR merges
-    # Look for PR merge commits
-    prs = []
-    for commit in commits_between:
-        if 'Merge pull request' in commit.message:
-            prs.append(extract_pr(commit.message))
+    prs = [extract_pr(c.message) for c in commits_between if is_pr(c.message)]
 
     if len(prs) == 0 and len(commits_between) > 0:
         raise Exception("Lots of commits and no PRs on branch {}".format(

--- a/changelog/__init__.py
+++ b/changelog/__init__.py
@@ -23,6 +23,8 @@ PullRequest = namedtuple('PullRequest', ['number', 'title'])
 
 # Merge commits use a double linebreak between the branch name and the title
 MERGE_PR_RE = re.compile(r'^Merge pull request #([0-9]+) from .*\n\n(.*)')
+
+# Squash-and-merge commits use the PR title with the number in parentheses
 SQUASH_PR_RE = re.compile(r'^(.*) \(#([0-9]+)\)\n\n.*')
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     url='https://github.com/cfpb/github-changelog',
     author='CFPB',
     license='CC0',
-    version='1.0.0',
+    version='1.1.0',
     include_package_data=True,
     packages=find_packages(),
     install_requires=[


### PR DESCRIPTION
This PR supports squash-and-merge commits within the changelog output.

For example, as of this writing, the [generator-cf commit #134 is an untagged squash-and-merge commit](https://github.com/cfpb/generator-cf/commit/fd299612ba1bb3ec5c69871ece11ddb607d1ddd4):

```
%> changelog cfpb generator-cf
- Added option to run http-server #134
- Updated to latest palette from the Design Manual #136
- update email address #133
- Update for renamed repo #131
```

As part of this, I refactored the way PR commits are discovered, making it entirely dependent on two regular expressions instead of a combination of string-matching and regex.