### PR TITLE
Fix squash-matching regex

### DIFF
--- a/changelog/__init__.py
+++ b/changelog/__init__.py
@@ -25,7 +25,7 @@ PullRequest = namedtuple('PullRequest', ['number', 'title'])
 MERGE_PR_RE = re.compile(r'^Merge pull request #([0-9]+) from .*\n\n(.*)')
 
 # Squash-and-merge commits use the PR title with the number in parentheses
-SQUASH_PR_RE = re.compile(r'^(.*) \(#([0-9]+)\)\n\n.*')
+SQUASH_PR_RE = re.compile(r'^(.*) \(#([0-9]+)\).*')
 
 
 class GitHubError(Exception):

--- a/changelog/tests/test_changelog.py
+++ b/changelog/tests/test_changelog.py
@@ -140,10 +140,10 @@ class TestChangelog(TestCase):
         message = 'Merge pull request from some/branch\n\nMy Title'
         self.assertFalse(is_pr(message))
 
-    def test_is_pr_not_squash(self):
+    def test_is_pr_potential_squash(self):
         """ Test our PR extractor with non-squashed PR message """
         message = 'Some title addresses bug (#345)'
-        self.assertFalse(is_pr(message))
+        self.assertTrue(is_pr(message))
 
     def test_extract_pr_merge(self):
         """ Test our PR extractor with merge PRa """
@@ -171,8 +171,9 @@ class TestChangelog(TestCase):
         with self.assertRaises(Exception):
             extract_pr(message)
 
-    def test_extract_pr_not_squash(self):
+    def test_extract_pr_potential_squash(self):
         """ Test our PR extractor with non-squashed PR message """
         message = 'Some title addresses bug (#345)'
-        with self.assertRaises(Exception):
-            extract_pr(message)
+        result = extract_pr(message)
+        self.assertEqual(result.number, '345')
+        self.assertEqual(result.title, 'Some title addresses bug')


### PR DESCRIPTION
This PR addresses a problem with the squash-and-merge-matching regular expressed [described in #6](https://github.com/cfpb/github-changelog/pull/6#discussion_r129583905).