### PR TITLE
Add Ability to Target GitHub Enterprise Instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ Use the optional `--github-base-url`, `--github-api-url`, and `--github-token` a
 
 ```bash
 changelog owner some-repo \
---github-base-url "https://company.github.com" \
---github-api-url "https://company.github.com/api/v3" \
+--github-base-url "https://github.company.com" \
+--github-api-url "https://github.company.com/api/v3" \
 --github-token secret-value
 ```
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,17 @@ changelog -m cfpb github-changelog 1.0.0 1.0.1
 
 Will generate a markdown changelog between `1.0.0` and `1.0.1`.
 
+## GitHub Enterprise Support
+
+Use the optional `--github-base-url`, `--github-api-url`, and `--github-token` arguments to connect to a GitHub Enterprise instance. For example:
+
+```bash
+changelog owner some-repo \
+--github-base-url "https://company.github.com" \
+--github-api-url "https://company.github.com/api/v3" \
+--github-token secret-value
+```
+
 ## Getting help
 
 Please add issues to the [issue tracker](https://github.com/cfpb/wagtail-flags/issues).

--- a/changelog/__init__.py
+++ b/changelog/__init__.py
@@ -217,12 +217,12 @@ def main():
                         help='output as single line joined by \\n characters')
     parser.add_argument('--github-base-url', type=str, action='store',
                         default=PUBLIC_GITHUB_URL, help='Override if you '
-                        'are using GitHub Enterprise. e.g. https://my-company'
-                        '.github.com')
+                        'are using GitHub Enterprise. e.g. https://github.'
+                        'my-company.com')
     parser.add_argument('--github-api-url', type=str, action='store',
                         default=PUBLIC_GITHUB_API_URL, help='Override if you '
-                        'are using GitHub Enterprise. e.g. https://my-company'
-                        '.github.com/api/v3')
+                        'are using GitHub Enterprise. e.g. https://github.'
+                        'my-company.com/api/v3')
     parser.add_argument('--github-token', type=str, action='store',
                         default=None, help='GitHub oauth token to auth '
                         'your Github requests with')

--- a/changelog/tests/test_changelog.py
+++ b/changelog/tests/test_changelog.py
@@ -220,14 +220,14 @@ class TestChangelog(TestCase):
 
     def test_format_changes_uses_correct_base_url(self):
         """ Test format_changes() with a custom GitHub base url """
-        github_config = get_github_config('https://company.github.com',
-                                          'https://company.github.com/api/v3',
+        github_config = get_github_config('https://github.company.com',
+                                          'https://github.company.com/api/v3',
                                           token=None)
         prs = [PullRequest(1, 'first'), PullRequest(2, 'second')]
         actual = format_changes(github_config, 'owner', 'a-repo', prs,
                                 markdown=True)
         expected = [
-            '- first [#1](https://company.github.com/owner/a-repo/pull/1)',
-            '- second [#2](https://company.github.com/owner/a-repo/pull/2)'
+            '- first [#1](https://github.company.com/owner/a-repo/pull/1)',
+            '- second [#2](https://github.company.com/owner/a-repo/pull/2)'
         ]
         self.assertEqual(actual, expected)

--- a/changelog/tests/test_changelog.py
+++ b/changelog/tests/test_changelog.py
@@ -3,21 +3,55 @@
 from unittest import TestCase
 
 import mock
-
 from changelog import (
+    PUBLIC_GITHUB_API_URL,
+    PUBLIC_GITHUB_URL,
     GitHubError,
-    get_commit_for_tag,
-    get_last_commit,
-    get_commits_between,
-    is_pr,
+    PullRequest,
     extract_pr,
+    format_changes,
+    get_commit_for_tag,
+    get_commits_between,
+    get_github_config,
+    get_last_commit,
+    is_pr,
 )
+
+fake_github_config = get_github_config(PUBLIC_GITHUB_URL,
+                                       PUBLIC_GITHUB_API_URL,
+                                       'fake-github-token')
 
 
 class TestChangelog(TestCase):
 
     def setUp(self):
         pass
+
+    def test_get_github_config(self):
+        """ Tests that exercise get_github_config() """
+        create_args_to_outputs = [
+            [
+                # when token=None, headers should be an empty dict
+                ('base-url', 'api-url', None),
+                {'base_url': 'base-url', 'api_url': 'api-url', 'headers': {}},
+            ],
+
+            [
+                # when a token is provided, headers should be non-empty
+                ('base-url', 'api-url', 'secret-value'),
+                {
+                    'base_url': 'base-url',
+                    'api_url': 'api-url',
+                    'headers': {'Authorization': 'token secret-value'}
+                },
+            ],
+        ]
+        for create_args, expected_output in create_args_to_outputs:
+            github_config = get_github_config(*create_args)
+
+            # note _asdict() is actually a documented "public" method
+            # despite its leading underscore
+            self.assertEqual(github_config._asdict(), expected_output)
 
     @mock.patch('requests.get')
     def test_get_commit_for_tag_exists(self, mock_requests_get):
@@ -28,7 +62,8 @@ class TestChangelog(TestCase):
             'object': {'type': 'commit', 'sha': '0123456789abcdef'}
         }
         mock_requests_get.return_value = response
-        result = get_commit_for_tag('someone', 'one-repo', 'myorg')
+        result = get_commit_for_tag(fake_github_config, 'someone', 'one-repo',
+                                    'myorg')
         self.assertEqual(result, '0123456789abcdef')
 
     @mock.patch('requests.get')
@@ -39,7 +74,8 @@ class TestChangelog(TestCase):
         response.json.return_value = {'message': 'nope'}
         mock_requests_get.return_value = response
         with self.assertRaises(GitHubError):
-            get_commit_for_tag('someone', 'one-repo', 'myorg')
+            get_commit_for_tag(fake_github_config, 'someone', 'one-repo',
+                               'myorg')
 
     @mock.patch('requests.get')
     def test_get_commit_for_tag_tag_object(self, mock_requests_get):
@@ -55,7 +91,8 @@ class TestChangelog(TestCase):
             {'object': {'type': 'commit', 'sha': '0123456789abcdef'}}
         ]
         mock_requests_get.return_value = response
-        result = get_commit_for_tag('someone', 'one-repo', 'myorg')
+        result = get_commit_for_tag(fake_github_config, 'someone', 'one-repo',
+                                    'myorg')
         self.assertEqual(result, '0123456789abcdef')
 
     @mock.patch('requests.get')
@@ -65,7 +102,7 @@ class TestChangelog(TestCase):
         response.status_code = 200
         response.json.return_value = [{'sha': '0123456789abcdef'}]
         mock_requests_get.return_value = response
-        result = get_last_commit('someone', 'one-repo')
+        result = get_last_commit(fake_github_config, 'someone', 'one-repo')
         self.assertEqual(result, '0123456789abcdef')
 
     @mock.patch('requests.get')
@@ -76,7 +113,7 @@ class TestChangelog(TestCase):
         response.json.return_value = {'message': 'nope'}
         mock_requests_get.return_value = response
         with self.assertRaises(GitHubError):
-            get_last_commit('someone', 'one-repo')
+            get_last_commit(fake_github_config, 'someone', 'one-repo')
 
     @mock.patch('requests.get')
     def test_get_commits_between(self, mock_requests_get):
@@ -96,7 +133,8 @@ class TestChangelog(TestCase):
             ]
         }
         mock_requests_get.return_value = response
-        result = get_commits_between('someone', 'one-repo', 'one', 'two')
+        result = get_commits_between(fake_github_config, 'someone', 'one-repo',
+                                     'one', 'two')
         self.assertEqual(
             result, [('0123456789abcdef', 'Foo'), ('123456789abcdef0', 'Bar')])
 
@@ -108,7 +146,8 @@ class TestChangelog(TestCase):
         response.json.return_value = {}
         mock_requests_get.return_value = response
         with self.assertRaises(GitHubError):
-            get_commits_between('someone', 'one-repo', 'one', 'two')
+            get_commits_between(fake_github_config, 'someone', 'one-repo',
+                                'one', 'two')
 
     @mock.patch('requests.get')
     def test_get_commits_between_not_found(self, mock_requests_get):
@@ -118,7 +157,8 @@ class TestChangelog(TestCase):
         response.json.return_value = {'message': 'nope'}
         mock_requests_get.return_value = response
         with self.assertRaises(GitHubError):
-            get_commits_between('someone', 'one-repo', 'one', 'two')
+            get_commits_between(fake_github_config, 'someone', 'one-repo',
+                                'one', 'two')
 
     def test_is_pr_merge(self):
         """ Test our PR extractor with merge PRa """
@@ -177,3 +217,17 @@ class TestChangelog(TestCase):
         result = extract_pr(message)
         self.assertEqual(result.number, '345')
         self.assertEqual(result.title, 'Some title addresses bug')
+
+    def test_format_changes_uses_correct_base_url(self):
+        """ Test format_changes() with a custom GitHub base url """
+        github_config = get_github_config('https://company.github.com',
+                                          'https://company.github.com/api/v3',
+                                          token=None)
+        prs = [PullRequest(1, 'first'), PullRequest(2, 'second')]
+        actual = format_changes(github_config, 'owner', 'a-repo', prs,
+                                markdown=True)
+        expected = [
+            '- first [#1](https://company.github.com/owner/a-repo/pull/1)',
+            '- second [#2](https://company.github.com/owner/a-repo/pull/2)'
+        ]
+        self.assertEqual(actual, expected)


### PR DESCRIPTION
This PR adds support for running `changelog` against a GitHub Enterprise instance.

Thanks for this project! 

## Additions

- Introduce the `namedtuple` `GitHubConfig` to store the necessary urls and headers needed to make requests to an arbitrary GitHub instance

## Changes

- Methods that make network requests to GitHub now require a `GitHubConfig` object as their first argument

## Notes
- Adding an additional positional argument to most of the fcn signatures in this script felt a little ugly, but it also seemed in line with the general style of this script (pretty functional)
    - Happy to write this changeset in a more class-based way if that would be preferred

## Testing

- Example usage targeting a repo on a GitHub Enterprise instance:
```bash
davidmuller$ python changelog/__init__.py \
> dmuller test-repo v1.0 \
> --markdown \
> --github-base-url "https://github.guidebook.com" \
> --github-api-url "https://github.guidebook.com/api/v3" \
> --github-token *********  
- change after release 1 [#1](https://github.guidebook.com/dmuller/test-repo/pull/1)  
```
- Example usage targeting `encode/django-rest-framework`
```bash
davidmuller$ python changelog/__init__.py \
encode django-rest-framework 3.7.3 \
--markdown
- Typos in serializers documentation [#5652](https://github.com/encode/django-rest-framework/pull/5652)
- Add '.basename' and '.reverse_action()' to ViewSet [#5648](https://github.com/encode/django-rest-framework/pull/5648)
- Note AutoSchema limitations on bare APIView [#5649](https://github.com/encode/django-rest-framework/pull/5649)
[truncated]
```

## Review

[Preview this PR without the whitespace changes](?w=0)

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [X] New functions include new tests
* [X] New functions are documented (with a description, list of inputs, and expected output)
* [X] Placeholder code is flagged
* N/A Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
