### PR TITLE
Bump version to 1.2.0 in preparation for release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ cache: pip
 matrix:
   include:
     - env: TOXENV=flake8
-      python: 3.5
+      python: 3.6
     - env: TOXENV=py27
       python: 2.7
-    - env: TOXENV=py35
-      python: 3.5
+    - env: TOXENV=py36
+      python: 3.6
 
 install:
   pip install tox coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,13 @@ script:
 
 after_success:
   coveralls
+
+deploy:
+  provider: pypi
+  distributions: "sdist bdist_wheel --universal"
+  user: cfpb
+  password:
+    secure: "F4CZ9q72ZToy9djdi3FYa7Zimx+P/Xuf+8BNjiiNfC8zGpczbkehs6h6Ou2CvjATFyCoYnRoDMwd4WW3EkyouCpNpAkT6GDnlogN65oNl0So9xmBWaXKYN8RY43dqVgiPkMWMwSKWk9h99JMocufurNW0BVwQenPz1M9t4zIHWEo/EFxkxvVtIdO5HN9L94tDAhYrSFS2Bzn4s0XpGEBCp0TjTClPRT/pao7IBfQRgOYuXsMGwILZQ8zaU8nESjEOYtKy7M23IGHRp61znxuOMz/pgUKQEK++DLWIDkfyWSXeFXmvenSvV8XSf7voPlwkvuni/+t0LZLmvSKKWoxeGLGt+1GdM5Dtc0jYzIb9h/Y1emNGOlxgbGiB+0hRl/87r3+XIT+aqkdaOuzAd+afBu17e7AbFt7zRDZS8NbL53xDgoosjpPKiqBQdQ+5cMgiJQH+2aunwbKiUmUkERXgOPQY0B8JWoIGrkF2I/BuICPq/8MUT/D3rQ32wfsQGfWDoAzNxOyFmowkuXwuE1qccXnX/T6fqx0fU3uA2mI2KbgA/0sns3Iu2YGUafqXRwj9XMnXBZXWdZGRvhy45sLrJZI8RW2656CUjhrG2ssoIcKHIqKPZ59OWGMz+tnGA97OulGbclPAOULMRr+B8kUEanE68yB2ZMfoPF+YZBsGVc="
+  on:
+    tags: true
+    condition: $TOXENV = "py36"

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,19 @@
 from setuptools import find_packages, setup
 
+
+with open('README.md') as f:
+    long_description = f.read()
+
+
 setup(
     name='github-changelog',
     url='https://github.com/cfpb/github-changelog',
     author='CFPB',
     license='CC0',
-    version='1.1.0',
+    version='1.2.0',
+    description='GitHub Pull Request changelog generator',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     include_package_data=True,
     packages=find_packages(),
     install_requires=[

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,18 @@
 [tox]
 skipsdist=True
-envlist=py27,py35,flake8
+envlist=py27,py36,flake8
 
 [testenv]
 basepython=
     py27: python2.7
-    py35: python3.5
+    py36: python3.6
 deps=.[testing]
 commands=
     coverage erase
     coverage run --source='changelog' setup.py test {posargs}
 
 [testenv:flake8]
-basepython=python3.5
+basepython=python3.6
 commands=flake8 changelog
 
 [flake8]


### PR DESCRIPTION
This PR bumps the version number in anticipation of creating a release. It also configures Travis to submit that release to PyPI when it's tagged and does some setup.py housekeeping in preparation for that. I've also bumped the Python 3 version to 3.6 for the unit tests.