### PR TITLE
Update README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An example might look like:
 ## Installing
 
 ```
-pip install git+https://github.com/cfpb/github-changelog
+pip install github-changelog
 ```
 
 ## Using


### PR DESCRIPTION
Apologies if you intended to update the install instructions in a later step.

Also, the project description's markdown [isn't rendering](https://pypi.org/project/github-changelog/).  
`setup.py` seems to be in order, but there are some [local steps](https://packaging.python.org/guides/making-a-pypi-friendly-readme/).