### PR TITLE
adding optional argument for branch, updating README with usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ changelog -m cfpb github-changelog 1.0.0 1.0.1
 
 Will generate a markdown changelog between `1.0.0` and `1.0.1`.
 
+## Overriding the Default Branch
+
+The default branch is set to `main`. To override this, use the optional `--branch` argument to specify a different branch. For example:
+
+```bash
+changelog owner some-repo \
+--branch "production"
+```
+
 ## GitHub Enterprise Support
 
 Use the optional `--github-base-url`, `--github-api-url`, and `--github-token` arguments to connect to a GitHub Enterprise instance. For example:
@@ -63,6 +72,7 @@ Please add issues to the [issue tracker](https://github.com/cfpb/wagtail-flags/i
 General instructions on _how_ to contribute can be found in [CONTRIBUTING](CONTRIBUTING.md).
 
 ## Open source licensing info
+
 1. [TERMS](TERMS.md)
 2. [LICENSE](LICENSE)
 3. [CFPB Source Code Policy](https://github.com/cfpb/source-code-policy/)

--- a/changelog/__init__.py
+++ b/changelog/__init__.py
@@ -155,8 +155,7 @@ def fetch_changes(github_config, owner, repo, previous_tag=None,
         current_commit = get_last_commit(github_config, owner, repo, branch)
 
     commits_between = get_commits_between(github_config, owner, repo,
-                                          previous_commit, current_commit,
-                                          branch)
+                                          previous_commit, current_commit)
 
     # Process the commit list looking for PR merges
     prs = [extract_pr(c.message) for c in commits_between if is_pr(c.message)]

--- a/changelog/__init__.py
+++ b/changelog/__init__.py
@@ -96,8 +96,7 @@ def get_last_tag(github_config, owner, repo):
     return tags_json[0]['name']
 
 
-def get_commits_between(github_config, owner, repo, first_commit, last_commit,
-                        branch=DEFAULT_BRANCH):
+def get_commits_between(github_config, owner, repo, first_commit, last_commit):
     """ Get a list of commits between two commits """
     commits_url = '/'.join([
         github_config.api_url,
@@ -106,8 +105,7 @@ def get_commits_between(github_config, owner, repo, first_commit, last_commit,
         'compare',
         first_commit + '...' + last_commit
     ])
-    commits_response = requests.get(commits_url, params={'sha': branch},
-                                    headers=github_config.headers)
+    commits_response = requests.get(commits_url, headers=github_config.headers)
     commits_json = commits_response.json()
     if commits_response.status_code != 200:
         raise GitHubError("Unable to get commits between {} and {}. {}".format(

--- a/changelog/__init__.py
+++ b/changelog/__init__.py
@@ -96,7 +96,8 @@ def get_last_tag(github_config, owner, repo):
     return tags_json[0]['name']
 
 
-def get_commits_between(github_config, owner, repo, first_commit, last_commit, branch=DEFAULT_BRANCH):
+def get_commits_between(github_config, owner, repo, first_commit, last_commit,
+                        branch=DEFAULT_BRANCH):
     """ Get a list of commits between two commits """
     commits_url = '/'.join([
         github_config.api_url,
@@ -156,7 +157,8 @@ def fetch_changes(github_config, owner, repo, previous_tag=None,
         current_commit = get_last_commit(github_config, owner, repo, branch)
 
     commits_between = get_commits_between(github_config, owner, repo,
-                                          previous_commit, current_commit, branch)
+                                          previous_commit, current_commit,
+                                          branch)
 
     # Process the commit list looking for PR merges
     prs = [extract_pr(c.message) for c in commits_between if is_pr(c.message)]
@@ -187,13 +189,16 @@ def format_changes(github_config, owner, repo, prs, markdown=False):
 
 
 def generate_changelog(owner, repo, previous_tag=None, current_tag=None,
-                       markdown=False, single_line=False, branch=None, github_base_url=None,
-                       github_api_url=None, github_token=None):
+                       markdown=False, single_line=False, branch=None,
+                       github_base_url=None, github_api_url=None,
+                       github_token=None):
 
     github_config = get_github_config(github_base_url, github_api_url,
                                       github_token)
 
-    prs = fetch_changes(github_config, owner, repo, previous_tag, current_tag, branch)
+    prs = fetch_changes(
+        github_config, owner, repo, previous_tag, current_tag, branch
+    )
     lines = format_changes(github_config, owner, repo, prs, markdown=markdown)
 
     separator = '\\n' if single_line else '\n'

--- a/changelog/__init__.py
+++ b/changelog/__init__.py
@@ -12,6 +12,7 @@ from collections import namedtuple
 
 import requests
 
+DEFAULT_BRANCH = 'main'
 PUBLIC_GITHUB_URL = 'https://github.com'
 PUBLIC_GITHUB_API_URL = 'https://api.github.com'
 GitHubConfig = namedtuple('GitHubConfig', ['base_url', 'api_url', 'headers'])
@@ -68,7 +69,7 @@ def get_commit_for_tag(github_config, owner, repo, tag):
     return tag_json['object']['sha']
 
 
-def get_last_commit(github_config, owner, repo, branch='main'):
+def get_last_commit(github_config, owner, repo, branch=DEFAULT_BRANCH):
     """ Get the last commit sha for the given repo and branch """
     commits_url = '/'.join([
         github_config.api_url,
@@ -76,7 +77,7 @@ def get_last_commit(github_config, owner, repo, branch='main'):
         owner, repo,
         'commits'
     ])
-    commits_response = requests.get(commits_url, params={'sha': 'main'},
+    commits_response = requests.get(commits_url, params={'sha': branch},
                                     headers=github_config.headers)
     commits_json = commits_response.json()
     if commits_response.status_code != 200:
@@ -95,7 +96,7 @@ def get_last_tag(github_config, owner, repo):
     return tags_json[0]['name']
 
 
-def get_commits_between(github_config, owner, repo, first_commit, last_commit):
+def get_commits_between(github_config, owner, repo, first_commit, last_commit, branch=DEFAULT_BRANCH):
     """ Get a list of commits between two commits """
     commits_url = '/'.join([
         github_config.api_url,
@@ -104,7 +105,7 @@ def get_commits_between(github_config, owner, repo, first_commit, last_commit):
         'compare',
         first_commit + '...' + last_commit
     ])
-    commits_response = requests.get(commits_url, params={'sha': 'main'},
+    commits_response = requests.get(commits_url, params={'sha': branch},
                                     headers=github_config.headers)
     commits_json = commits_response.json()
     if commits_response.status_code != 200:
@@ -141,7 +142,7 @@ def extract_pr(message):
 
 
 def fetch_changes(github_config, owner, repo, previous_tag=None,
-                  current_tag=None, branch='main'):
+                  current_tag=None, branch=DEFAULT_BRANCH):
     if previous_tag is None:
         previous_tag = get_last_tag(github_config, owner, repo)
     previous_commit = get_commit_for_tag(github_config, owner, repo,
@@ -155,7 +156,7 @@ def fetch_changes(github_config, owner, repo, previous_tag=None,
         current_commit = get_last_commit(github_config, owner, repo, branch)
 
     commits_between = get_commits_between(github_config, owner, repo,
-                                          previous_commit, current_commit)
+                                          previous_commit, current_commit, branch)
 
     # Process the commit list looking for PR merges
     prs = [extract_pr(c.message) for c in commits_between if is_pr(c.message)]
@@ -186,13 +187,13 @@ def format_changes(github_config, owner, repo, prs, markdown=False):
 
 
 def generate_changelog(owner, repo, previous_tag=None, current_tag=None,
-                       markdown=False, single_line=False, github_base_url=None,
+                       markdown=False, single_line=False, branch=None, github_base_url=None,
                        github_api_url=None, github_token=None):
 
     github_config = get_github_config(github_base_url, github_api_url,
                                       github_token)
 
-    prs = fetch_changes(github_config, owner, repo, previous_tag, current_tag)
+    prs = fetch_changes(github_config, owner, repo, previous_tag, current_tag, branch)
     lines = format_changes(github_config, owner, repo, prs, markdown=markdown)
 
     separator = '\\n' if single_line else '\n'
@@ -215,6 +216,9 @@ def main():
                         help='output in markdown')
     parser.add_argument('-s', '--single-line', action='store_true',
                         help='output as single line joined by \\n characters')
+    parser.add_argument('--branch', type=str, action='store',
+                        default=DEFAULT_BRANCH, help='Override the '
+                        'target branch (defaults to main)')
     parser.add_argument('--github-base-url', type=str, action='store',
                         default=PUBLIC_GITHUB_URL, help='Override if you '
                         'are using GitHub Enterprise. e.g. https://github.'

--- a/changelog/tests/test_changelog.py
+++ b/changelog/tests/test_changelog.py
@@ -63,23 +63,23 @@ class TestChangelog(TestCase):
         }
         mock_requests_get.return_value = response
         result = get_commit_for_tag(fake_github_config, 'someone', 'one-repo',
-                                    'myorg')
+                                    'mytag')
         self.assertEqual(result, '0123456789abcdef')
 
     @mock.patch('requests.get')
     def test_get_commit_for_tag_not_found(self, mock_requests_get):
-        """ Test getting the commit sha for a tag if the tag exists """
+        """ Getting commit sha for a tag fails if tag doesn't exist """
         response = mock.MagicMock()
         response.status_code = 404
         response.json.return_value = {'message': 'nope'}
         mock_requests_get.return_value = response
         with self.assertRaises(GitHubError):
             get_commit_for_tag(fake_github_config, 'someone', 'one-repo',
-                               'myorg')
+                               'mytag')
 
     @mock.patch('requests.get')
     def test_get_commit_for_tag_tag_object(self, mock_requests_get):
-        """ Test getting the commit sha when tagged object is tag """
+        """ Test getting the commit sha when tagged object is itself a tag """
         response = mock.MagicMock()
         response.status_code = 200
         response.json.side_effect = [
@@ -92,12 +92,12 @@ class TestChangelog(TestCase):
         ]
         mock_requests_get.return_value = response
         result = get_commit_for_tag(fake_github_config, 'someone', 'one-repo',
-                                    'myorg')
+                                    'mytag')
         self.assertEqual(result, '0123456789abcdef')
 
     @mock.patch('requests.get')
     def test_get_last_commit_exists(self, mock_requests_get):
-        """ Test getting the commit sha for a tag if the tag exists """
+        """ Test getting commit sha for latest commit on the default branch """
         response = mock.MagicMock()
         response.status_code = 200
         response.json.return_value = [{'sha': '0123456789abcdef'}]
@@ -106,8 +106,19 @@ class TestChangelog(TestCase):
         self.assertEqual(result, '0123456789abcdef')
 
     @mock.patch('requests.get')
+    def test_get_last_commit_custom_branch(self, mock_requests_get):
+        """ Test getting commit sha for latest commit on a specific branch """
+        response = mock.MagicMock()
+        response.status_code = 200
+        response.json.return_value = [{'sha': '0123456789abcdef'}]
+        mock_requests_get.return_value = response
+        result = get_last_commit(fake_github_config, 'someone', 'one-repo',
+                                 'not-default-branch')
+        self.assertEqual(result, '0123456789abcdef')
+
+    @mock.patch('requests.get')
     def test_get_last_commit_not_found(self, mock_requests_get):
-        """ Test getting the commit sha for a tag if the tag exists """
+        """ Getting the commit sha for latest commit fails if no commits """
         response = mock.MagicMock()
         response.status_code = 404
         response.json.return_value = {'message': 'nope'}


### PR DESCRIPTION
Fixes #15: Sometimes I need to be able to specify a branch other than `main`.

## Additions

- Adds `--branch` argument to `generate_changelog()`
- Adds `DEFAULT_BRANCH='main'` variable that is used as the default if no branch argument is provided

## Changes

- Modifies all previous usage of `main` to use the `branch` argument which defaults to `DEFAULT_BRANCH`

## Testing

- Tests still pass, confirming that the `DEFAULT_BRANCH` is passed correctly
- There isn't a test for `generate_changelog()` so I'm not quite sure how to test a custom branch name.

## Review

[Preview this PR without the whitespace changes](?w=0)

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG) -- But I am not sure what the `"Unreleased" section of the CHANGELOG` is
