### PR TITLE
Extend ChangeLog Generation parsing PR body

### DIFF
--- a/changelog/__init__.py
+++ b/changelog/__init__.py
@@ -20,12 +20,16 @@ GitHubConfig = namedtuple("GitHubConfig", ["base_url", "api_url", "headers"])
 
 Commit = namedtuple("Commit", ["sha", "message"])
 PullRequest = namedtuple("PullRequest", ["number", "title"])
+ExtendedPullRequest = namedtuple("ExtendedPullRequest", ["pr", "changelog"])
 
 # Merge commits use a double linebreak between the branch name and the title
 MERGE_PR_RE = re.compile(r"^Merge pull request #([0-9]+) from .*\n\n(.*)")
 
 # Squash-and-merge commits use the PR title with the number in parentheses
 SQUASH_PR_RE = re.compile(r"^(.*) \(#([0-9]+)\).*")
+
+# Changelog Identifier Regex. Ex.: CHANGELOG: Added some stuff
+CHANGELOG_RE = re.compile(r"^CHANGELOG:\w?(.*)")
 
 
 class GitHubError(Exception):
@@ -139,6 +143,40 @@ def get_commits_between(github_config, owner, repo, first_commit, last_commit):
     return commits
 
 
+def get_pr_body(github_config, owner, repo, pr_number):
+    """Get the body of the identified PR"""
+    pr_url = "/".join(
+        [
+            github_config.api_url,
+            "repos",
+            owner,
+            repo,
+            "pulls",
+            pr_number,
+        ]
+    )
+    pr_response = requests.get(pr_url, headers=github_config.headers)
+    pr_json = pr_response.json()
+    if pr_response.status_code != 200:
+        raise GitHubError(
+            "Unable to get PR # {}. {}".format(
+                pr_number, pr_response["message"]
+            )
+        )
+
+    return pr_json["body"]
+
+
+def extract_changelog(pr_body):
+    """Extracts the Changelog from the PR Body"""
+    changelog_match = CHANGELOG_RE.match(pr_body)
+    try:
+        changelog = changelog.groups()
+        return changelog
+    except:
+        return None
+
+
 def is_pr(message):
     """Determine whether or not a commit message is a PR merge"""
     return MERGE_PR_RE.search(message) or SQUASH_PR_RE.search(message)
@@ -188,19 +226,28 @@ def fetch_changes(
     # Process the commit list looking for PR merges
     prs = [extract_pr(c.message) for c in commits_between if is_pr(c.message)]
 
-    if len(prs) == 0 and len(commits_between) > 0:
+    extended_prs = []
+
+    for pr in prs:
+        pr_body = get_pr_body(github_config, owner, repo, pr.number)
+        extended_prs.append(
+            ExtendedPullRequest(pr, extract_changelog(pr_body))
+        )
+
+    if len(extended_prs) == 0 and len(commits_between) > 0:
         raise Exception(
             "Lots of commits and no PRs on branch {}".format(branch)
         )
 
-    prs.reverse()
-    return prs
+    extended_prs.reverse()
+    return extended_prs
 
 
 def format_changes(github_config, owner, repo, prs, markdown=False):
     """Format the list of prs in either text or markdown"""
     lines = []
-    for pr in prs:
+    for extended_pr in prs:
+        pr = extended_pr.pr
         number = "#{number}".format(number=pr.number)
         if markdown:
             link = "{github_url}/{owner}/{repo}/pull/{number}".format(
@@ -210,9 +257,13 @@ def format_changes(github_config, owner, repo, prs, markdown=False):
                 number=pr.number,
             )
             number = "[{number}]({link})".format(number=number, link=link)
-
         lines.append(
-            "- {title} {number}".format(title=pr.title, number=number)
+            "- {description} {number}".format(
+                description=extended_pr.changelog
+                if extended_pr.changelog != None
+                else pr.title,
+                number=number,
+            )
         )
 
     return lines

--- a/changelog/tests/test_changelog.py
+++ b/changelog/tests/test_changelog.py
@@ -8,6 +8,7 @@ from changelog import (
     PUBLIC_GITHUB_API_URL,
     PUBLIC_GITHUB_URL,
     GitHubError,
+    ExtendedPullRequest,
     PullRequest,
     extract_pr,
     format_changes,
@@ -241,7 +242,7 @@ class TestChangelog(TestCase):
             "https://github.company.com/api/v3",
             token=None,
         )
-        prs = [PullRequest(1, "first"), PullRequest(2, "second")]
+        prs = [ExtendedPullRequest(PullRequest(1, "first"), None), ExtendedPullRequest(PullRequest(2, "second"), None)]
         actual = format_changes(
             github_config, "owner", "a-repo", prs, markdown=True
         )
@@ -369,6 +370,34 @@ class TestChangelog(TestCase):
             ]
         }
         responses.append(get_commits_between_response)
+
+        get_pr_body_response = mock.MagicMock()
+        get_pr_body_response.status_code = 200
+        get_pr_body_response.json.return_value = {
+            "body": "My Title #5"
+        }
+        responses.append(get_pr_body_response)
+
+        get_pr_body_response = mock.MagicMock()
+        get_pr_body_response.status_code = 200
+        get_pr_body_response.json.return_value = {
+            "body": "My Title #5"
+        }
+        responses.append(get_pr_body_response)
+
+        get_pr_body_response = mock.MagicMock()
+        get_pr_body_response.status_code = 200
+        get_pr_body_response.json.return_value = {
+            "body": "My Title #5"
+        }
+        responses.append(get_pr_body_response)
+
+        get_pr_body_response = mock.MagicMock()
+        get_pr_body_response.status_code = 200
+        get_pr_body_response.json.return_value = {
+            "body": "My Title #5"
+        }
+        responses.append(get_pr_body_response)
 
         mock_requests_get.side_effect = responses
         result = generate_changelog(

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
 skipsdist=True
-envlist=lint,py36,py38
+envlist=lint,py38
 
 [testenv]
 basepython=
-    py36: python3.6
     py38: python3.8
 deps=.[testing]
 commands=


### PR DESCRIPTION
The title of a PR is sometimes not the best way to describe a change within the changelog

## Additions

- Pull body of each identified PRs
- Choose change identified in Body over PR title for ChangeLog generation

## Removals
NA

## Changes

-

## Testing

-

## Review

- @user

[Preview this PR without the whitespace changes](?w=0)

## Screenshots


## Notes

-

## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
